### PR TITLE
DD-974. dd-workflow-step-vault-metadata fails if previous versions are deaccessioned

### DIFF
--- a/src/main/scala/nl/knaw/dans/wf/vaultmd/legacy/SetVaultMetadataTaskScala.scala
+++ b/src/main/scala/nl/knaw/dans/wf/vaultmd/legacy/SetVaultMetadataTaskScala.scala
@@ -20,8 +20,8 @@ import nl.knaw.dans.lib.dataverse.model.workflow.ResumeMessage
 import nl.knaw.dans.lib.dataverse.{ DataverseClient, DataverseException, DataverseHttpResponse }
 import nl.knaw.dans.lib.error.TryExtensions
 import nl.knaw.dans.wf.vaultmd.core.SetVaultMetadataTask
-import org.json4s.{ Extraction, JObject, JValue }
-import org.json4s.native.{ JsonMethods, Serialization }
+import org.json4s.native.JsonMethods
+import org.json4s.{ JObject, JValue }
 import org.slf4j.LoggerFactory
 
 import java.lang.Thread._


### PR DESCRIPTION
Fixes DD-974

# Description of changes
The workflow step first checks whether there is a previous version from which to copy some of the metadata fields is must fill in (i.e. whether the version to be published is > 1.0). It used to assume that that previous version was a published version and therefore use `:latest-published` to obtain its metadata. However, it could also be a deaccessioned version. Therefore we now get all the versions with `versionState` on either `RELEASED` ("published") or `DEACCESSIONED` and then get the one with the highest version number.

# How to test
```
deploy.py -m dd-workflow-step-vault-metadata
```
Execute the scenario in the issue. Also check that scenarios not involving deaccessioning still work.

# Notify
@DANS-KNAW/dataversedans
