### PR TITLE
Fix DD-1211 bagId not correctly minted

### DIFF
--- a/src/main/java/nl/knaw/dans/wf/vaultmd/core/DataverseService.java
+++ b/src/main/java/nl/knaw/dans/wf/vaultmd/core/DataverseService.java
@@ -32,8 +32,14 @@ public interface DataverseService {
 
     Optional<DatasetVersion> getVersion(StepInvocation stepInvocation, String name) throws DataverseException, IOException;
 
-    Optional<DatasetVersion> getLatestReleasedOrDeaccessionedVersion(StepInvocation stepInvocation) throws DataverseException, IOException;
-
+    /**
+     * Gets all dataset versions from Dataverse in descending order
+     *
+     * @param stepInvocation
+     * @return a list of DatasetVersion objects that have status RELEASED or DEACCESSIONED sorted in descending order
+     * @throws DataverseException
+     * @throws IOException
+     */
     Collection<DatasetVersion> getAllReleasedOrDeaccessionedVersion(StepInvocation stepInvocation) throws DataverseException, IOException;
 
     void lockDataset(StepInvocation stepInvocation, String workflow) throws DataverseException, IOException;

--- a/src/main/java/nl/knaw/dans/wf/vaultmd/core/DataverseServiceImpl.java
+++ b/src/main/java/nl/knaw/dans/wf/vaultmd/core/DataverseServiceImpl.java
@@ -62,7 +62,7 @@ public class DataverseServiceImpl implements DataverseService {
 
     @Override
     public Collection<DatasetVersion> getAllReleasedOrDeaccessionedVersion(StepInvocation stepInvocation) throws DataverseException, IOException {
-        return getDataset(stepInvocation).getAllVersions().getData().stream()
+        return getAllDatasetVersions(stepInvocation).stream()
             .filter(d -> Set.of("RELEASED", "DEACCESSIONED").contains(d.getVersionState()))
             .sorted((a, b) -> -1 * versionComparator.compare(a, b))
             .collect(Collectors.toList());
@@ -82,4 +82,7 @@ public class DataverseServiceImpl implements DataverseService {
         return dataverseClient.dataset(stepInvocation.getGlobalId(), stepInvocation.getInvocationId());
     }
 
+    Collection<DatasetVersion> getAllDatasetVersions(StepInvocation stepInvocation) throws IOException, DataverseException {
+        return getDataset(stepInvocation).getAllVersions().getData();
+    }
 }

--- a/src/main/java/nl/knaw/dans/wf/vaultmd/core/DataverseServiceImpl.java
+++ b/src/main/java/nl/knaw/dans/wf/vaultmd/core/DataverseServiceImpl.java
@@ -61,16 +61,10 @@ public class DataverseServiceImpl implements DataverseService {
     }
 
     @Override
-    public Optional<DatasetVersion> getLatestReleasedOrDeaccessionedVersion(StepInvocation stepInvocation) throws DataverseException, IOException {
-        return getDataset(stepInvocation).getAllVersions().getData().stream()
-            .filter(d -> Set.of("RELEASED", "DEACCESSIONED").contains(d.getVersionState()))
-            .max(versionComparator);
-    }
-
-    @Override
     public Collection<DatasetVersion> getAllReleasedOrDeaccessionedVersion(StepInvocation stepInvocation) throws DataverseException, IOException {
         return getDataset(stepInvocation).getAllVersions().getData().stream()
             .filter(d -> Set.of("RELEASED", "DEACCESSIONED").contains(d.getVersionState()))
+            .sorted((a, b) -> -1 * versionComparator.compare(a, b))
             .collect(Collectors.toList());
     }
 

--- a/src/test/java/nl/knaw/dans/wf/vaultmd/core/DataverseServiceImplTest.java
+++ b/src/test/java/nl/knaw/dans/wf/vaultmd/core/DataverseServiceImplTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2021 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.wf.vaultmd.core;
+
+import nl.knaw.dans.lib.dataverse.DataverseClient;
+import nl.knaw.dans.wf.vaultmd.api.StepInvocation;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DataverseServiceImplTest {
+
+    @Test
+    void getAllReleasedOrDeaccessionedVersion_should_return_versions_in_descending_order() throws Exception {
+        var service = Mockito.spy(new DataverseServiceImpl(Mockito.mock(DataverseClient.class)));
+        var step = new StepInvocation("invocationId", "globalId", "datasetId", "1", "5");
+
+        var version1 = TestUtilities.createDatasetVersion("bagId1", "nbn", 1, 1, "RELEASED");
+        var version2 = TestUtilities.createDatasetVersion("bagId2", "nbn", 1, 2, "RELEASED");
+        var version3 = TestUtilities.createDatasetVersion("bagId3", "nbn", 1, 3, "RELEASED");
+
+        Mockito.doReturn(List.of(version1, version3, version2))
+            .when(service).getAllDatasetVersions(Mockito.any());
+
+        var result = new ArrayList<>(service.getAllReleasedOrDeaccessionedVersion(step));
+
+        assertEquals(3, result.get(0).getVersionMinorNumber());
+        assertEquals(2, result.get(1).getVersionMinorNumber());
+        assertEquals(1, result.get(2).getVersionMinorNumber());
+    }
+
+}

--- a/src/test/java/nl/knaw/dans/wf/vaultmd/core/SetVaultMetadataTaskTest.java
+++ b/src/test/java/nl/knaw/dans/wf/vaultmd/core/SetVaultMetadataTaskTest.java
@@ -16,9 +16,7 @@
 package nl.knaw.dans.wf.vaultmd.core;
 
 import nl.knaw.dans.lib.dataverse.DataverseException;
-import nl.knaw.dans.lib.dataverse.model.dataset.DatasetVersion;
 import nl.knaw.dans.lib.dataverse.model.dataset.FieldList;
-import nl.knaw.dans.lib.dataverse.model.dataset.MetadataBlock;
 import nl.knaw.dans.lib.dataverse.model.dataset.MetadataField;
 import nl.knaw.dans.lib.dataverse.model.dataset.PrimitiveSingleValueField;
 import nl.knaw.dans.wf.vaultmd.api.StepInvocation;
@@ -29,13 +27,13 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static nl.knaw.dans.wf.vaultmd.core.TestUtilities.createDatasetVersion;
+import static nl.knaw.dans.wf.vaultmd.core.TestUtilities.createDatasetVersionWithoutVaultMetadataBlock;
 import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -49,47 +47,6 @@ class SetVaultMetadataTaskTest {
 
     private final IdMintingService mintingServiceMock = Mockito.spy(new IdMintingServiceImpl());
     private final IdValidator idValidator = new IdValidatorImpl();
-
-    /*
-     * Helper functions
-     */
-    private static DatasetVersion createDatasetVersion(String bagId, String nbn, int version, int versionMinor, String versionState) {
-        var datasetVersion = new DatasetVersion();
-        datasetVersion.setVersionNumber(version);
-        datasetVersion.setVersionMinorNumber(versionMinor);
-        datasetVersion.setVersionState(versionState);
-        datasetVersion.setMetadataBlocks(new HashMap<>());
-
-        var block = new MetadataBlock();
-        block.setFields(new ArrayList<>());
-
-        if (bagId != null) {
-            block.getFields().add(new PrimitiveSingleValueField("dansBagId", bagId));
-        }
-
-        if (nbn != null) {
-            block.getFields().add(new PrimitiveSingleValueField("dansNbn", nbn));
-        }
-
-        block.getFields().add(new PrimitiveSingleValueField("dansDataversePid", "globalId"));
-
-        datasetVersion.getMetadataBlocks().put("dansDataVaultMetadata", block);
-
-        return datasetVersion;
-    }
-
-    private static DatasetVersion createDatasetVersionWithoutVaultMetadataBlock(int version, int versionMinor, String versionState) {
-        var datasetVersion = new DatasetVersion();
-        datasetVersion.setVersionNumber(version);
-        datasetVersion.setVersionMinorNumber(versionMinor);
-        datasetVersion.setVersionState(versionState);
-        datasetVersion.setMetadataBlocks(new HashMap<>());
-
-        var block = new MetadataBlock();
-        block.setFields(new ArrayList<>());
-
-        return datasetVersion;
-    }
 
     private static AbstractStringAssert<?> assertThatMetadataField(FieldList fieldList, String property) {
         return assertThat(fieldList.getFields())

--- a/src/test/java/nl/knaw/dans/wf/vaultmd/core/SetVaultMetadataTaskTest.java
+++ b/src/test/java/nl/knaw/dans/wf/vaultmd/core/SetVaultMetadataTaskTest.java
@@ -118,8 +118,6 @@ class SetVaultMetadataTaskTest {
 
         Mockito.when(dataverseServiceMock.getVersion(Mockito.any(), Mockito.any()))
             .thenReturn(Optional.of(draft));
-        Mockito.when(dataverseServiceMock.getLatestReleasedOrDeaccessionedVersion(Mockito.any()))
-            .thenReturn(Optional.of(previous));
         Mockito.when(dataverseServiceMock.getAllReleasedOrDeaccessionedVersion(Mockito.any()))
             .thenReturn(List.of(previous));
 
@@ -140,8 +138,8 @@ class SetVaultMetadataTaskTest {
 
         Mockito.when(dataverseServiceMock.getVersion(Mockito.any(), Mockito.any()))
             .thenReturn(Optional.of(draft));
-        Mockito.when(dataverseServiceMock.getLatestReleasedOrDeaccessionedVersion(Mockito.any()))
-            .thenReturn(Optional.of(previous));
+        Mockito.when(dataverseServiceMock.getAllReleasedOrDeaccessionedVersion(Mockito.any()))
+            .thenReturn(List.of(previous));
         Mockito.when(mintingServiceMock.mintBagId()).thenReturn(newBagId);
 
         var step = new StepInvocation("invokeId", "globalId", "datasetId", "1", "1");
@@ -163,8 +161,8 @@ class SetVaultMetadataTaskTest {
 
         Mockito.when(dataverseServiceMock.getVersion(Mockito.any(), Mockito.any()))
             .thenReturn(Optional.of(draft));
-        Mockito.when(dataverseServiceMock.getLatestReleasedOrDeaccessionedVersion(Mockito.any()))
-            .thenReturn(Optional.empty());
+        Mockito.when(dataverseServiceMock.getAllReleasedOrDeaccessionedVersion(Mockito.any()))
+            .thenReturn(List.of());
         Mockito.when(mintingServiceMock.mintBagId()).thenReturn(newBagId);
         Mockito.when(mintingServiceMock.mintUrnNbn()).thenReturn(newNbn);
 
@@ -189,8 +187,8 @@ class SetVaultMetadataTaskTest {
 
         Mockito.when(dataverseServiceMock.getVersion(Mockito.any(), Mockito.any()))
             .thenReturn(Optional.of(draft));
-        Mockito.when(dataverseServiceMock.getLatestReleasedOrDeaccessionedVersion(Mockito.any()))
-            .thenReturn(Optional.of(previous));
+        Mockito.when(dataverseServiceMock.getAllReleasedOrDeaccessionedVersion(Mockito.any()))
+            .thenReturn(List.of(previous));
 
         var step = new StepInvocation("invokeId", "globalId", "datasetId", "1", "1");
         var task = createTask(step);
@@ -211,8 +209,8 @@ class SetVaultMetadataTaskTest {
 
         Mockito.when(dataverseServiceMock.getVersion(Mockito.any(), Mockito.any()))
             .thenReturn(Optional.of(draft));
-        Mockito.when(dataverseServiceMock.getLatestReleasedOrDeaccessionedVersion(Mockito.any()))
-            .thenReturn(Optional.empty());
+        Mockito.when(dataverseServiceMock.getAllReleasedOrDeaccessionedVersion(Mockito.any()))
+            .thenReturn(List.of());
         Mockito.when(mintingServiceMock.mintBagId()).thenReturn(newBagId);
         Mockito.when(mintingServiceMock.mintUrnNbn()).thenReturn(newNbn);
 
@@ -235,8 +233,8 @@ class SetVaultMetadataTaskTest {
 
         Mockito.when(dataverseServiceMock.getVersion(Mockito.any(), Mockito.any()))
             .thenReturn(Optional.of(draft));
-        Mockito.when(dataverseServiceMock.getLatestReleasedOrDeaccessionedVersion(Mockito.any()))
-            .thenReturn(Optional.empty());
+        Mockito.when(dataverseServiceMock.getAllReleasedOrDeaccessionedVersion(Mockito.any()))
+            .thenReturn(List.of());
         Mockito.when(mintingServiceMock.mintBagId()).thenReturn(newBagId);
         Mockito.when(mintingServiceMock.mintUrnNbn()).thenReturn(newNbn);
 
@@ -261,8 +259,8 @@ class SetVaultMetadataTaskTest {
 
         Mockito.when(dataverseServiceMock.getVersion(Mockito.any(), Mockito.any()))
             .thenReturn(Optional.of(draft));
-        Mockito.when(dataverseServiceMock.getLatestReleasedOrDeaccessionedVersion(Mockito.any()))
-            .thenReturn(Optional.of(previous));
+        Mockito.when(dataverseServiceMock.getAllReleasedOrDeaccessionedVersion(Mockito.any()))
+            .thenReturn(List.of(previous));
         Mockito.when(mintingServiceMock.mintBagId())
             .thenReturn(newBagId);
 
@@ -271,6 +269,36 @@ class SetVaultMetadataTaskTest {
         var metadata = task.getVaultMetadata(step);
 
         // the draft does not have a bag ID, but the previous version has, so it should mint a new bag ID
+        assertThatMetadataField(metadata, "dansDataversePid").isEqualTo("globalId");
+        assertThatMetadataField(metadata, "dansDataversePidVersion").isEqualTo("1.1");
+        assertThatMetadataField(metadata, "dansBagId").isEqualTo(newBagId);
+        assertThatMetadataField(metadata, "dansNbn").isEqualTo(nbn);
+    }
+
+    @Test
+    void getVaultMetadata_with_previous_multiple_versions_should_mint_new_bagId() throws IOException, DataverseException {
+        final var bagId = "urn:uuid:cbdf4d18-65af-42d2-baf3-6ca07ddfd3b2";
+        final var deaccessionedBagId = "urn:uuid:6fcfe06e-7f24-4989-9a27-18317c1970bb";
+        final var newBagId = "urn:uuid:cbdf4d18-65af-42d2-baf3-6ca07ddfd3b2";
+        final var nbn = "urn:nbn:nl:ui:13-73750978-5587-4e2b-937f-6b190e44fcae";
+
+        var draft = createDatasetVersion(bagId, null, 1, 1, "DRAFT");
+        var previous = createDatasetVersion(bagId, nbn, 1, 0, "RELEASED");
+        var deaccessioned = createDatasetVersion(deaccessionedBagId, nbn, 1, 0, "DEACCESSIONED");
+
+        Mockito.when(dataverseServiceMock.getVersion(Mockito.any(), Mockito.any()))
+            .thenReturn(Optional.of(draft));
+        Mockito.when(dataverseServiceMock.getAllReleasedOrDeaccessionedVersion(Mockito.any()))
+            .thenReturn(List.of(deaccessioned, previous));
+        Mockito.when(mintingServiceMock.mintBagId())
+            .thenReturn(newBagId);
+
+        var step = new StepInvocation("invokeId", "globalId", "datasetId", "1", "1");
+        var task = createTask(step);
+        var metadata = task.getVaultMetadata(step);
+
+        // the draft has the same ID as the previously published version, but different from the latest version which is deaccessioned
+        // see https://drivenbydata.atlassian.net/browse/DD-1211 for more details
         assertThatMetadataField(metadata, "dansDataversePid").isEqualTo("globalId");
         assertThatMetadataField(metadata, "dansDataversePidVersion").isEqualTo("1.1");
         assertThatMetadataField(metadata, "dansBagId").isEqualTo(newBagId);

--- a/src/test/java/nl/knaw/dans/wf/vaultmd/core/TestUtilities.java
+++ b/src/test/java/nl/knaw/dans/wf/vaultmd/core/TestUtilities.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2021 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.wf.vaultmd.core;
+
+import nl.knaw.dans.lib.dataverse.model.dataset.DatasetVersion;
+import nl.knaw.dans.lib.dataverse.model.dataset.MetadataBlock;
+import nl.knaw.dans.lib.dataverse.model.dataset.PrimitiveSingleValueField;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+public class TestUtilities {
+    public static DatasetVersion createDatasetVersion(String bagId, String nbn, int version, int versionMinor, String versionState) {
+        var datasetVersion = new DatasetVersion();
+        datasetVersion.setVersionNumber(version);
+        datasetVersion.setVersionMinorNumber(versionMinor);
+        datasetVersion.setVersionState(versionState);
+        datasetVersion.setMetadataBlocks(new HashMap<>());
+
+        var block = new MetadataBlock();
+        block.setFields(new ArrayList<>());
+
+        if (bagId != null) {
+            block.getFields().add(new PrimitiveSingleValueField("dansBagId", bagId));
+        }
+
+        if (nbn != null) {
+            block.getFields().add(new PrimitiveSingleValueField("dansNbn", nbn));
+        }
+
+        block.getFields().add(new PrimitiveSingleValueField("dansDataversePid", "globalId"));
+
+        datasetVersion.getMetadataBlocks().put("dansDataVaultMetadata", block);
+
+        return datasetVersion;
+    }
+
+    public static DatasetVersion createDatasetVersionWithoutVaultMetadataBlock(int version, int versionMinor, String versionState) {
+        var datasetVersion = new DatasetVersion();
+        datasetVersion.setVersionNumber(version);
+        datasetVersion.setVersionMinorNumber(versionMinor);
+        datasetVersion.setVersionState(versionState);
+        datasetVersion.setMetadataBlocks(new HashMap<>());
+
+        var block = new MetadataBlock();
+        block.setFields(new ArrayList<>());
+
+        return datasetVersion;
+    }
+}


### PR DESCRIPTION
Dataverse seems to use the latest published version to inherit existing metadata fields into the draft version. The issue is that a deaccessioned version would be used to compare to, and the bag ID in the draft would be different from the deaccesioned version, thus no new bag ID was minted.

This commit fixes that by comparing it to all previous versions that are either published or deaccesioned to make sure no duplicate bag ID ends up in the drafts metadata.

Fixes DD-1211

# Description of changes


# How to test


# Related PRs
(Add links)
*

# Notify
@DANS-KNAW/dataversedans
