### PR TITLE
Use dataverse client lib updated to support 5.14

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
         <dependency>
             <groupId>nl.knaw.dans</groupId>
             <artifactId>dans-dataverse-client-lib</artifactId>
+            <version>0.20.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>nl.knaw.dans</groupId>


### PR DESCRIPTION
DD-1417 Update For Dataverse v5.14

# Description of changes
Use dataverse client lib updated to support 5.14

Note that for testing the version is set directly to the SNAPSHOT, but that should become the 'real' version and placed in the 'parent' pom and then here, that new parent pom should be used. 

# How to test

To build this you first need to build the client lib from the related PR https://github.com/DANS-KNAW/dans-dataverse-client-lib/pull/44

The copy the jars, of both this service and the client lib to the server. 
On the dev box the client lib has to be placed here:
`/opt/dans.knaw.nl/dd-vault-metadata/lib/dans-dataverse-client-lib-0.20.1-SNAPSHOT.jar`
And the service binary here: 
`/opt/dans.knaw.nl/dd-vault-metadata/bin/dd-vault-metadata-1.1.1-SNAPSHOT.jar`
There is a link that must be changed to this new jar:
```
sudo rm /opt/dans.knaw.nl/dd-vault-metadata/bin/dd-vault-metadata.jar
sudo ln -s /opt/dans.knaw.nl/dd-vault-metadata/bin/dd-vault-metadata-1.1.1-SNAPSHOT.jar /opt/dans.knaw.nl/dd-vault-metadata/bin/dd-vault-metadata.jar
```
Permissions have to be changed with `sudo chmod 744`.  And you have to restart the service with `sudo systemctl restart dd-vault-metadata`. 

Watch the log with:
```
tail -F /var/opt/dans.knaw.nl/log/dd-vault-metadata/dd-vault-metadata.log
```

# Related PRs

(Add links)

* https://github.com/DANS-KNAW/dans-dataverse-client-lib/pull/44

# Notify

@DANS-KNAW/dataversedans
