### PR TITLE
DD-2043  Failed publication of dataset after it was deaccessioned

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>nl.knaw.dans</groupId>
             <artifactId>dans-dataverse-client-lib</artifactId>
-
+            <version>1.4.1</version>
         </dependency>
         <dependency>
             <groupId>nl.knaw.dans</groupId>


### PR DESCRIPTION
Fixes DD-2043 Failed publication of dataset after it was deaccessioned

# Description of changes

Need to rebuild dd-vault-metadata because there is a new version of dans-dataverse-client-lib

# How to test
Zie DD-2043

# Related PRs

(Add links)

*

# Notify

@DANS-KNAW/core-systems
