### PR TITLE
DD-2142 Use last version of dans-dataverse-client-lib - II

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>nl.knaw.dans</groupId>
         <artifactId>dd-parent</artifactId>
-        <version>1.11.0</version>
+        <version>1.11.1</version>
     </parent>
 
     <artifactId>dd-vault-metadata</artifactId>


### PR DESCRIPTION
Fixes DD-2142  Use last version of dans-dataverse-client-lib

# Description of changes
- update pom file to use last dd-parent 1.11.1

# How to test
mvnci --> should use dans-dataverse-client-lib 1.5.1

# Related PRs

(Add links)

*

# Notify

@DANS-KNAW/core-systems
